### PR TITLE
V0.9.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+#### Version 0.9.6
+- [X] Add SqlFormat,e.g:`"SqlServerDb".SqlFormat("select * from {1}orders{2} where id = {0}id")` equals `select * from [orders] where id = @id`
+
 #### Version 0.9.5
 - [X] Add DbCache Model for ParameterPrefix,QuotePrefix,QuoteSuffix
 - [X] Add Common Connection CreateParameter Without DbCommand

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 #### Version 0.9.6
-- [X] Add SqlFormat,e.g:`"SqlServerDb".SqlFormat("select * from {1}orders{2} where id = {0}id")` equals `select * from [orders] where id = @id`
+- [X] Add SqlFormat , e.g:
+```C#
+var sql = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
+//if db is sqlserver
+Assert.Equal("select * from [orders] where id = @id", sql);
+
+//if db is oracle
+Assert.Equal("select * from \"orders\" where id = :id", sql); 
+```
 
 #### Version 0.9.5
 - [X] Add DbCache Model for ParameterPrefix,QuotePrefix,QuoteSuffix

--- a/DbSqlHelper/Db.cs
+++ b/DbSqlHelper/Db.cs
@@ -149,11 +149,32 @@ namespace DbSqlHelper
     //String Format
     public static partial class Db
     {
-        //public static string SqlFormat(this string key,string sql)
-        //{
-        //    var cache =  key.GetDbCache();
-        //    sql = Regex.Replace(sql,"")
-        //    return "";
-        //}
+        /// <summary>
+        /// {0} = ParameterPrefix , {1} = QuotePrefix , {2} = QuoteSuffix , 
+        /// e.g
+        /// 1. <code>"SqlServerDb".SqlFormat("select * from {1}orders{2} where id = {0}id")</code> equals <code>select * from [orders] where id = @id</code>
+        /// 2. <code>"OracleDb".SqlFormat("select * from {1}orders{2} where id = {0}id")</code> equals <code>select * from "orders" where id = :id</code>
+        /// </summary>
+        /// <param name="key">DataBase Cache Key</param>
+        /// <param name="sql">Format Sql</param>
+        public static string SqlFormat(string sql) => "".SqlFormat(sql);
+
+        /// <summary>
+        /// {0} = ParameterPrefix , {1} = QuotePrefix , {2} = QuoteSuffix , 
+        /// e.g
+        /// 1. <code>"SqlServerDb".SqlFormat("select * from {1}orders{2} where id = {0}id")</code> equals <code>select * from [orders] where id = @id</code>
+        /// 2. <code>"OracleDb".SqlFormat("select * from {1}orders{2} where id = {0}id")</code> equals <code>select * from "orders" where id = :id</code>
+        /// </summary>
+        /// <param name="key">DataBase Cache Key</param>
+        /// <param name="sql">Format Sql</param>
+        public static string SqlFormat(this string key, string sql)
+        {
+            var cache = key.GetDbCache();
+            sql = sql.Replace("{0}", cache.ParameterPrefix)
+                .Replace("{1}", cache.QuotePrefix)
+                .Replace("{2}", cache.QuoteSuffix)
+                ;
+            return sql;
+        }
     }
 }

--- a/DbSqlHelper/DbSqlHelper.csproj
+++ b/DbSqlHelper/DbSqlHelper.csproj
@@ -11,15 +11,26 @@
     <PackageProjectUrl>https://github.com/shps951023/DbSqlHelper</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/shps951023/ImageHosting/master/img/2019-01-17.13.18.32-image.png</PackageIconUrl>
 
-    <AssemblyVersion>0.9.5</AssemblyVersion>
-    <FileVersion>0.9.5</FileVersion>
-    <Version>0.9.5</Version>
+    <AssemblyVersion>0.9.6</AssemblyVersion>
+    <FileVersion>0.9.6</FileVersion>
+    <Version>0.9.6</Version>
     <PackageId>DbSqlHelper</PackageId>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>DbSqlHelper</Product>
     <PackageTags>DB,Mini,Easy,Sql,SqlHelper</PackageTags>
     <RepositoryType>Github</RepositoryType>
-    <PackageReleaseNotes>#### Version 0.9.5
+    <PackageReleaseNotes>#### Version 0.9.6
+- [X] Add SqlFormat , e.g:
+```C#
+var sql = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
+//if db is sqlserver
+Assert.Equal("select * from [orders] where id = @id", sql);
+
+//if db is oracle
+Assert.Equal("select * from \"orders\" where id = :id", sql); 
+```
+
+#### Version 0.9.5
 - [X] Add DbCache Model for ParameterPrefix,QuotePrefix,QuoteSuffix
 - [X] Add Common Connection CreateParameter Without DbCommand
 - [X] Add `public static DBConnectionType GetDbConnectionType(this Type connectionType)`
@@ -35,6 +46,7 @@
 #### Version 0.9.2
 - [X] Add Db.AddConnection and GetConnection</PackageReleaseNotes>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/shps951023/DbSqlHelper</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DbSqlHelperTest/BaseTest.cs
+++ b/DbSqlHelperTest/BaseTest.cs
@@ -10,6 +10,9 @@ namespace DbSqlHelperTest
             var connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Integrated Security=SSPI;Initial Catalog=master;";
             Db.AddConnection<SqlConnection>(connectionString);
             Db.AddConnection(typeof(SqlConnection), connectionString);
+
+            "sqlserver".AddConnection<SqlConnection>(connectionString);
+            //"oracle".AddConnection<SqlConnection>(connectionString);
         }
     }
 }

--- a/DbSqlHelperTest/DbSqlHelperTest.csproj
+++ b/DbSqlHelperTest/DbSqlHelperTest.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.6" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.110" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/DbSqlHelperTest/DbTest.cs
+++ b/DbSqlHelperTest/DbTest.cs
@@ -8,10 +8,18 @@ namespace DbSqlHelperTest
         [Fact]
         public void SqlFormatTest()
         {
-            using (var cn = Db.GetConnection())
             {
-                var result = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
-                Assert.Equal("select * from [orders] where id = @id", result);
+                var sql = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
+                //if db is sqlserver
+                Assert.Equal("select * from [orders] where id = @id", sql);
+
+                //if db is oracle
+                //Assert.Equal("select * from "orders" where id = :id", sql); 
+            }
+
+            {
+                var sql = "sqlserver".SqlFormat("select * from {1}orders{2} where id = {0}id");
+                Assert.Equal("select * from [orders] where id = @id", sql);
             }
         }
     }

--- a/DbSqlHelperTest/DbTest.cs
+++ b/DbSqlHelperTest/DbTest.cs
@@ -1,0 +1,18 @@
+﻿using DbSqlHelper;
+using Xunit;
+
+namespace DbSqlHelperTest
+{
+    public class DbTest : BaseTest
+    {
+        [Fact]
+        public void SqlFormatTest()
+        {
+            using (var cn = Db.GetConnection())
+            {
+                var result = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
+                Assert.Equal("select * from [orders] where id = @id", result);
+            }
+        }
+    }
+}

--- a/DbSqlHelperTest/SqlTest.cs
+++ b/DbSqlHelperTest/SqlTest.cs
@@ -5,6 +5,7 @@ using System.Data;
 
 namespace DbSqlHelperTest
 {
+
     public class SqlTest : BaseTest
     {
         [Fact]

--- a/Readme.md
+++ b/Readme.md
@@ -73,11 +73,14 @@ using (var oracleCn = "OracleDb".GetConnection())
 }
 ```
 
-#### GetDbConnectionType
-
+#### SQL Format For ParameterPrefix,QuotePrefix,QuoteSuffix
 ```C#
-var result = Db.GetConnection().GetDbConnectionType();
-Assert.Equal(DBConnectionType.SqlServer, result);
+var sql = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
+//if db is sqlserver
+Assert.Equal("select * from [orders] where id = @id", sql); 
+
+//if db is oracle
+Assert.Equal("select * from \"orders\" where id = :id", sql); 
 ```
 
 #### GetDbConnection Cache Model(Get Connection ParameterPrefix,QuotePrefix,QuoteSuffix)
@@ -89,6 +92,12 @@ Assert.Equal("[", cache.QuotePrefix);
 Assert.Equal("]", cache.QuoteSuffix);
 ```
 
+#### GetDbConnectionType
+
+```C#
+var result = Db.GetConnection().GetDbConnectionType();
+Assert.Equal(DBConnectionType.SqlServer, result);
+```
 
 ----
 


### PR DESCRIPTION
#### Version 0.9.6
- [X] Add SqlFormat , e.g:
```C#
var sql = Db.SqlFormat("select * from {1}orders{2} where id = {0}id");
//if db is sqlserver
Assert.Equal("select * from [orders] where id = @id", sql);

//if db is oracle
Assert.Equal("select * from \"orders\" where id = :id", sql); 
```